### PR TITLE
fix: render durations with either 'min' or 'mins' label

### DIFF
--- a/src/containers/SearchContainer/SearchResults/SearchResultsContainer.jsx
+++ b/src/containers/SearchContainer/SearchResults/SearchResultsContainer.jsx
@@ -87,7 +87,7 @@ const SearchResultsContainer = ({ currentUser }) => {
             const rowObj = {
                 date: new Date(rowArray[0].split(': ')[1]), // 'Date: Monday Mar 29, 2021'
                 time: rowArray[1].split(': ')[1],
-                duration: rowArray[2].split(': ')[1].replace('minutes', 'min'),
+                duration: rowArray[2].split(': ')[1].replace(/[minute]+/, 'min'),
                 maxElevation: rowArray[3].split(': ')[1].split('&')[0],
                 approachDir: approachObj.split('above')[1].trim(),
                 approachDeg: approachObj.split(' ')[0].trim(),
@@ -170,7 +170,7 @@ const SearchResultsContainer = ({ currentUser }) => {
                 const itemData = xml.getElementsByTagName('item');
                 let cleanedData = cleanTableData(itemData);
                 cleanedData = filteredSightingCards(cleanedData);
-
+                console.log('cleanedData', cleanedData);
                 if (cleanedData && cleanedData.length) {
                     setSightingChart({ value: cleanedData, status: FETCH_SUCCESS });
                 } else {


### PR DESCRIPTION
# UI Bug Fix

## Summary

- [x] Incorporate `regex` to dynamically convert 'minute' to 'min' and 'minutes' to 'mins' before rendering.

## Expected Behavior

SightingCard should render duration in the following format:
  1. If time is 1: `<time> min`.
  2. If time is greater than 1: `<time> mins`.

## Actual Behavior

- SightingCard renders `1 minute`, if time is 1.