### PR TITLE
feat(sighting-cards): change onClick to toggle select one card at a time

### DIFF
--- a/src/components/sightingcard/SightingCard.jsx
+++ b/src/components/sightingcard/SightingCard.jsx
@@ -1,72 +1,66 @@
-import { useState } from 'react';
 import Compass from 'components/compass';
+
 import './style.scss';
 
-const SightingCard = ({ sightingData, header }) => {
-    const [renderDetails, setrenderDetails] = useState(false);
-
-    const renderDetailsHelper = () => {
-        !header && setrenderDetails(!renderDetails);
-    };
-
-    return (
-        <div className='sightingcard' onClick={renderDetailsHelper}>
-            <div className={header ? 'sightingheader' : 'card_overview'}>
-                <span id={header ? 'headerdatespan' : 'datespan'}>
-                    {header ? sightingData.date : sightingData.date.toDateString()}
+const SightingCard = ({ isSelected, selectSightingCard, sightingData, header }) => (
+    <div
+        className='sightingcard'
+        onClick={() => {
+            !header && selectSightingCard();
+        }}
+    >
+        <div className={header ? 'sightingheader' : 'card_overview'}>
+            <span id={header ? 'headerdatespan' : 'datespan'}>
+                {header ? sightingData.date : sightingData.date.toDateString()}
+            </span>
+            <span id={header ? 'headertimespan' : 'timespan'}>{sightingData.time}</span>
+            <span id={header ? 'headerdurationspan' : 'durationspan'}>{sightingData.duration}</span>
+            {!header ? (
+                <span
+                    id='sightingdownarrow'
+                    style={
+                        isSelected
+                            ? {
+                                  transform: 'rotate(180deg)',
+                                  paddingTop: '3px',
+                                  paddingLeft: '2px',
+                              }
+                            : null
+                    }
+                >
+                    ▼
                 </span>
-                <span id={header ? 'headertimespan' : 'timespan'}>{sightingData.time}</span>
-                <span id={header ? 'headerdurationspan' : 'durationspan'}>
-                    {sightingData.duration}
-                </span>
-                {!header ? (
-                    <span
-                        id='sightingdownarrow'
-                        style={
-                            renderDetails
-                                ? {
-                                      transform: 'rotate(180deg)',
-                                      paddingTop: '3px',
-                                      paddingLeft: '2px',
-                                  }
-                                : null
-                        }
-                    >
-                        ▼
-                    </span>
-                ) : (
-                    <span id='headerspacingspan'></span>
-                )}
-            </div>
-
-            {renderDetails ? (
-                <div className='card_detail'>
-                    <span className='detail_info'>
-                        <span className='detail_info_title'>Enters Sky</span>{' '}
-                        <span className='detail_info_data'>
-                            {sightingData.approachDir}: {sightingData.approachDeg} above horizon
-                        </span>
-                        <span className='detail_info_title'>Max Elevation</span>{' '}
-                        <span className='detail_info_data'>
-                            {' '}
-                            {sightingData.maxElevation}° above horizon
-                        </span>
-                        <span className='detail_info_title'>Leaves Sky</span>{' '}
-                        <span className='detail_info_data'>
-                            {sightingData.departureDir}: {sightingData.departureDeg} above horizon
-                        </span>
-                    </span>
-
-                    <span className='detail_compass'>
-                        <Compass
-                            entersSky={sightingData.approachDir}
-                            leavesSky={sightingData.departureDir}
-                        />
-                    </span>
-                </div>
-            ) : null}
+            ) : (
+                <span id='headerspacingspan'></span>
+            )}
         </div>
-    );
-};
+
+        {isSelected ? (
+            <div className='card_detail'>
+                <span className='detail_info'>
+                    <span className='detail_info_title'>Enters Sky</span>
+                    <span className='detail_info_data'>
+                        {sightingData.approachDir}: {sightingData.approachDeg} above horizon
+                    </span>
+                    <span className='detail_info_title'>Max Elevation</span>
+                    <span className='detail_info_data'>
+                        {sightingData.maxElevation}° above horizon
+                    </span>
+                    <span className='detail_info_title'>Leaves Sky</span>
+                    <span className='detail_info_data'>
+                        {sightingData.departureDir}: {sightingData.departureDeg} above horizon
+                    </span>
+                </span>
+
+                <span className='detail_compass'>
+                    <Compass
+                        entersSky={sightingData.approachDir}
+                        leavesSky={sightingData.departureDir}
+                    />
+                </span>
+            </div>
+        ) : null}
+    </div>
+);
 
 export default SightingCard;

--- a/src/components/sightingcard/SightingCardList.jsx
+++ b/src/components/sightingcard/SightingCardList.jsx
@@ -1,20 +1,48 @@
+import { useState } from 'react';
+
 import { FETCH_SUCCESS } from 'utils/constants';
 
 import SightingCard from './SightingCard';
 
-const LIMIT = 7;
+const LIMIT = 10;
 
 const SightingCardList = ({ tableData }) => {
+    const [selectedSightingCardByIndex, setSelectedSightingCardByIndex] = useState(null);
+
+    const selectSightingCard = (sightingCardIndex) => {
+        setSelectedSightingCardByIndex(sightingCardIndex);
+    };
+
+    const toggleSightingCard = (sightingCardIndex) => {
+        if (selectedSightingCardByIndex === sightingCardIndex) {
+            setSelectedSightingCardByIndex(null);
+        } else {
+            selectSightingCard(sightingCardIndex);
+        }
+    };
+
     const renderSightingCards = () => {
         if (tableData.value.length > LIMIT) {
             let count = -1;
             return tableData.value
                 .slice(0, LIMIT)
-                .map((rowObj) => <SightingCard key={++count} sightingData={rowObj} />);
+                .map((rowObj, index) => (
+                    <SightingCard
+                        key={++count}
+                        sightingData={rowObj}
+                        isSelected={selectedSightingCardByIndex === index}
+                        selectSightingCard={() => toggleSightingCard(index)}
+                    />
+                ));
         } else {
             let count = -1;
-            return tableData.value.map((rowObj) => (
-                <SightingCard key={++count} sightingData={rowObj} />
+            return tableData.value.map((rowObj, index) => (
+                <SightingCard
+                    key={++count}
+                    sightingData={rowObj}
+                    isSelected={selectedSightingCardByIndex === index}
+                    selectSightingCard={() => toggleSightingCard(index)}
+                />
             ));
         }
     };


### PR DESCRIPTION
Closes #44 

---

### Summary of Changes

- [x] **Change**: `onClick` will toggle select instead of expanding every card `onClick`.<sup>1</sup>
- [x] **Change**: Revert maximum limit to 10.


###### (1) Clicking on a SightingCard will de-select your prior selection while selecting (i.e., expanding) the newly selected card; clicking on a currently selected SightingCard will toggle select (i.e., it will close, if it was opened/selected).