### PR TITLE
feat(web/sighting-card): replace flex with grid

### DIFF
--- a/server/cleanTableData.ts
+++ b/server/cleanTableData.ts
@@ -27,6 +27,10 @@ const shouldIncludeSightingCard = (bareSightingCardDate, limitByNumOfDays = LIMI
     return result;
 };
 
+const prepareDateForClient = (sightingRecordDate: DateTime) => {
+    return sightingRecordDate.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY).replace(',', '');
+};
+
 // TODO: Refactor date handling for UI
 const filterTableData = (cleanData) => {
     return cleanData
@@ -38,7 +42,7 @@ const filterTableData = (cleanData) => {
         )
         .map((sightingRecord) => ({
             ...sightingRecord,
-            date: sightingRecord.date.toISODate(),
+            date: prepareDateForClient(sightingRecord.date),
         }));
 };
 
@@ -55,7 +59,6 @@ export const cleanTableData = (rawData) => {
             .trim()
             .replace('&#176;', '°');
 
-        // TODO: remove localization in Date
         const rowObj = {
             date: bareDate(new Date(rowArray[0].split(': ')[1])), // 'Date: Monday Mar 29, 2021'
             time: rowArray[1].split(': ')[1].trim(),

--- a/web/src/components/notification/Error.tsx
+++ b/web/src/components/notification/Error.tsx
@@ -6,7 +6,7 @@ const Error = () => {
     return (
         <div className='text-right'>
             {message && (
-                <span className='z-20 text-amber-800 border-amber-800 border-2 text-center font-basier rounded-md px-4 py-1'>
+                <span className='z-20 text-amber-800 border-amber-800 border-2 text-center font-basier rounded-md px-4 mt-4'>
                     {message}
                 </span>
             )}

--- a/web/src/components/search/search-bar.component.tsx
+++ b/web/src/components/search/search-bar.component.tsx
@@ -22,7 +22,7 @@ const SearchBar = ({ fetchGeoDataFromZip, currentUser }) => {
     return (
         <>
             <input
-                className='h-full p-4 font-basier text-gray-300 bg-stone-800 bg-opacity-50 border-neutral-400 outline-none border-2 placeholder:text-gray-400 focus:shadow-input'
+                className='h-full p-4 w-72 font-basier text-gray-300 bg-stone-800 bg-opacity-50 border-neutral-400 outline-none border-2 placeholder:text-gray-400 focus:shadow-input'
                 name='searchZipCode'
                 type='search'
                 placeholder='Enter ZIP Code'
@@ -33,7 +33,7 @@ const SearchBar = ({ fetchGeoDataFromZip, currentUser }) => {
             <input
                 ref={submitRef}
                 type='submit'
-                className='h-full w-20 font-basier text-sm bg-neutral-400 border-none rounded-r-md cursor-pointer hover:bg-stone-600 disabled:bg-stone-600 disabled:pointer-events-none'
+                className='h-full w-24 font-basier text-sm bg-neutral-400 border-none rounded-r-md cursor-pointer hover:bg-stone-600 disabled:bg-stone-600 disabled:pointer-events-none'
                 value='Search'
                 disabled={isUserSearching}
                 aria-disabled={isUserSearching}

--- a/web/src/components/sightingcard/SightingCard.tsx
+++ b/web/src/components/sightingcard/SightingCard.tsx
@@ -6,7 +6,8 @@ interface SightingCardProps {
     selectSightingCard?: (sightingCardIndex?: number) => void;
     sightingData: any;
 }
-
+const baseStyle =
+    'grid grid-cols-4 grid-flow-row auto-rows-max gap-4 p-4 text-gray-300 text-sm hover:text-stone-50';
 // TODO: Refactor SightingCard JSX with reusable components
 const SightingCard = ({
     isSelected,
@@ -15,53 +16,48 @@ const SightingCard = ({
     header = false,
 }: SightingCardProps) => (
     <div
-        className='flex flex-col justify-center content-center text-gray-300 p-4 text-sm hover:text-stone-50'
-        onClick={() => {
-            !header && selectSightingCard && selectSightingCard(); // TODO: refactor with appropriate type defs
-        }}
+        className={
+            header ? `${baseStyle} py-1 text-stone-50 text-lg` : `${baseStyle} cursor-pointer`
+        }
+        onClick={() => !header && selectSightingCard && selectSightingCard()} // TODO: refactor with appropriate type defs
     >
         <div
-            className={
-                header
-                    ? 'flex flex-row justify-between py-1 border-zinc-800 font-normal text-stone-50 text-lg'
-                    : 'flex flex-row justify-between items-center cursor-pointer'
-            }
+            // className={header ? 'flex justify-center pr-12 w-36' : 'w-32'}
+            className='col-span-2 hover:text-stone-50'
         >
-            <span className={header ? 'flex justify-center pr-12 w-36' : 'w-32'}>
-                {header ? sightingData.date : sightingData.date}
-            </span>
-            <span className={header ? 'flex flex-start w-10' : 'w-14'}>{sightingData.time}</span>
-            <span className={header ? 'flex flex-start' : 'w-14'}>{sightingData.duration}</span>
+            {sightingData.date}
+        </div>
+        <div className={header ? 'flex flex-start w-10' : 'w-14'}>{sightingData.time}</div>
+        <div className='flex justify-between'>
+            <div>{sightingData.duration}</div>
+            {/* TODO: refactor and cleanup */}
             {isSelected ? (
                 !header ? (
-                    <span className='text-xs w-3 mt-1'>▲</span>
-                ) : (
-                    <span></span>
-                )
+                    <div className='text-xs w-3 mt-2'>▲</div>
+                ) : null
             ) : !header ? (
-                <span className='text-xs w-3 mt-1'>▼</span>
-            ) : (
-                <span></span>
-            )}
+                <div className='text-xs w-3 mt-1'>▼</div>
+            ) : null}
         </div>
-
         {isSelected ? (
-            <div className='flex flex-row justify-evenly text-xs cursor-pointer mt-2'>
-                <div className='flex flex-col justify-center w-54'>
-                    <span className='mb-1 underline decoration-1 decoration-solid'>Enters Sky</span>
-                    <span className='mb-3'>
+            // className='grid grid-cols-2 col-span-3 justify-evenly text-xs cursor-pointer mt-2 w-72'
+            // className='flex flex-col justify-center w-54'
+            <div className='grid grid-cols-4 place-self-start place-content-center text-xs cursor-pointer mt-2 w-72'>
+                <div className='col-span-2 mt-4'>
+                    <div className='mb-1 underline decoration-1 decoration-solid'>Enters Sky</div>
+                    <div className='mb-3'>
                         {sightingData.approachDir}: {sightingData.approachDeg} above horizon
-                    </span>
-                    <span className='mb-1 underline decoration-1 decoration-solid'>
+                    </div>
+                    <div className='mb-1 underline decoration-1 decoration-solid'>
                         Max Elevation
-                    </span>
-                    <span className='mb-3'>{sightingData.maxElevation}° above horizon</span>
-                    <span className='mb-1 underline decoration-1 decoration-solid'>Leaves Sky</span>
-                    <span className='mb-3'>
+                    </div>
+                    <div className='mb-3'>{sightingData.maxElevation}° above horizon</div>
+                    <div className='mb-1 underline decoration-1 decoration-solid'>Leaves Sky</div>
+                    <div className='mb-3'>
                         {sightingData.departureDir}: {sightingData.departureDeg} above horizon
-                    </span>
+                    </div>
                 </div>
-                <div>
+                <div className='col-span-2'>
                     <Compass
                         entersSky={sightingData.approachDir}
                         leavesSky={sightingData.departureDir}
@@ -71,5 +67,13 @@ const SightingCard = ({
         ) : null}
     </div>
 );
+
+SightingCard.defaultProps = {
+    sightingData: {
+        date: 'DATE',
+        time: 'TIME',
+        duration: 'DURATION',
+    },
+};
 
 export default SightingCard;

--- a/web/src/components/sightingcard/SightingCard.tsx
+++ b/web/src/components/sightingcard/SightingCard.tsx
@@ -7,7 +7,7 @@ interface SightingCardProps {
     sightingData: any;
 }
 const baseStyle =
-    'grid grid-cols-4 grid-flow-row auto-rows-max gap-4 p-4 text-gray-300 text-sm hover:text-stone-50';
+    'grid grid-cols-4 grid-flow-row auto-rows-max gap-4 p-4 text-gray-300 text-base hover:text-stone-50';
 // TODO: Refactor SightingCard JSX with reusable components
 const SightingCard = ({
     isSelected,
@@ -27,7 +27,7 @@ const SightingCard = ({
         >
             {sightingData.date}
         </div>
-        <div className={header ? 'flex flex-start w-10' : 'w-14'}>{sightingData.time}</div>
+        <div className={header ? 'flex flex-start' : ''}>{sightingData.time}</div>
         <div className='flex justify-between'>
             <div>{sightingData.duration}</div>
             {/* TODO: refactor and cleanup */}

--- a/web/src/components/sightingcard/SightingCardList.tsx
+++ b/web/src/components/sightingcard/SightingCardList.tsx
@@ -46,26 +46,18 @@ const SightingCardList = ({ tableData }) => {
         ));
     };
 
-    const headerData = {
-        date: 'DATE',
-        time: 'TIME',
-        duration: 'DURATION',
-    };
-
     const renderList =
         tableData.status === FETCH_SUCCESS ? (
-            <div className='flex flex-col text-white bg-zinc-900 bg-opacity-75 rounded-md animate-fade-in'>
-                <div>
-                    <h2 className='font-garet text-lg text-center text-white underline pt-4 tracking-wide'>
-                        Sighting Opportunities
-                    </h2>
-                </div>
-                <div className='divide-zinc-700 divide-y-2 last:divide-0'>
-                    <SightingCard header sightingData={headerData} />
+            <div className='text-white bg-zinc-900 bg-opacity-75 rounded-lg animate-fade-in'>
+                <h2 className='font-garet text-lg text-center text-white underline pt-4 tracking-wide'>
+                    Sighting Opportunities
+                </h2>
+                <div className='text-gray-300 text-sm divide-zinc-700 divide-y-2 last:divide-0'>
+                    <SightingCard header />
                     {renderSightingCards()}
                 </div>
             </div>
-        ) : null;
+        ) : null; // TODO: consider adding default component for such situations instead of null
 
     return renderList;
 };

--- a/web/src/containers/SearchContainer/SearchContainer.tsx
+++ b/web/src/containers/SearchContainer/SearchContainer.tsx
@@ -4,7 +4,7 @@ import DropdownContainer from './Dropdown';
 import SearchResultsContainer from './SearchResults';
 
 const SearchContainer = ({ fetchGeoDataFromZip, currentUser, setCurrentUser }) => (
-    <div className='fixed right-12 top-14 z-10 h-12'>
+    <div className='fixed right-12 top-14 z-10 h-12 w-96'>
         <Search fetchGeoDataFromZip={fetchGeoDataFromZip} currentUser={currentUser}>
             <DropdownContainer currentUser={currentUser} setCurrentUser={setCurrentUser} />
         </Search>


### PR DESCRIPTION
## Summary

- [x] Replace flex with grid when rendering search results.
- [x] Minor refactor by leveraging `defaultProps`.


## Screenshot

Demo of layout with grid instead of flex:

<img width="433" alt="sighting-card-with-grid-demo" src="https://user-images.githubusercontent.com/47502769/150664352-15b5c85f-123e-4b3f-8cdb-d897c9b8b996.png">
