### PR TITLE
security: address code scanning alert for server-side request forgery

### DIFF
--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,5 +1,7 @@
 import { DateTime } from 'luxon';
 
+import type geoMap from './data/geoMap.json';
+
 export interface IChannelItem {
     description: string;
     guid: string;
@@ -34,3 +36,21 @@ export interface ICleanData {
     maxElevation: string;
     time: string;
 }
+
+export interface ObservationPoint {
+    latitude: number;
+    longitude: number;
+    city: string;
+}
+
+export type ValidCountry = keyof typeof geoMap;
+
+export type ValidState<Country extends ValidCountry> = Country extends keyof typeof geoMap
+    ? keyof (typeof geoMap)[Country]
+    : never;
+
+export type GeoMap = Readonly<{
+    [country in ValidCountry]: {
+        [state in ValidState<country>]: ReadonlyArray<ObservationPoint>;
+    };
+}>;


### PR DESCRIPTION
Fixes [https://github.com/kylejb/space-station-tracker/security/code-scanning/1](https://github.com/kylejb/space-station-tracker/security/code-scanning/1)

To fix the problem, we need to validate and sanitize the user input before using it to construct the URL. Specifically, we should ensure that the values for `country`, `state`, and `city` are from a predefined list of allowed values. This will prevent attackers from injecting malicious input into the URL.

1. Create a list of allowed values for `country`, `state`, and `city`.
2. Validate the user input against these lists.
3. If the input is valid, proceed with constructing the URL and making the request.
4. If the input is invalid, return an appropriate error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
