### PR TITLE
security: address code scanning alert for missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
         "dotenv": "^16.4.5",
         "express": "^5.0.0",
         "fast-xml-parser": "^4.5.0",
-        "luxon": "^3.5.0"
+        "luxon": "^3.5.0",
+        "express-rate-limit": "^7.4.1"
     },
     "devDependencies": {
         "@types/express": "^5.0.0",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,6 +3,7 @@ import { json } from 'body-parser';
 import express, { Express, Request, Response } from 'express';
 import { XMLParser } from 'fast-xml-parser';
 import path from 'path';
+import rateLimit from 'express-rate-limit';
 
 import { cleanTableData } from './cleanTableData';
 import { SpotTheStationResponse } from './types';
@@ -14,6 +15,13 @@ export class Server {
     constructor(app: Express) {
         this.app = app;
         this.app.disable('x-powered-by'); // security
+
+        const limiter = rateLimit({
+            windowMs: 15 * 60 * 1000, // 15 minutes
+            max: 100, // limit each IP to 100 requests per windowMs
+        });
+
+        this.app.use(limiter);
 
         this.app.use(express.static(path.resolve('../dist/web')));
 


### PR DESCRIPTION
Fixes [https://github.com/kylejb/space-station-tracker/security/code-scanning/4](https://github.com/kylejb/space-station-tracker/security/code-scanning/4)

To fix the problem, we will introduce a rate-limiting middleware using the `express-rate-limit` package. This middleware will limit the number of requests that can be made to the server within a specified time window. We will apply this middleware to the entire application to ensure that all routes, including the one serving the file, are protected.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server.ts` file.
3. Set up the rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter middleware to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
