### PR TITLE
security(server): address code scanning alert for missing rate limiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7975,6 +7975,21 @@
                 "node": ">= 18"
             }
         },
+        "node_modules/express-rate-limit": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.1.tgz",
+            "integrity": "sha512-KS3efpnpIDVIXopMc65EMbWbUht7qvTCdtCR2dD/IZmi9MIkopYESwyRqLgv8Pfu589+KqDqOdzJWW7AHoACeg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": "4 || 5 || ^5.0.0-beta.1"
+            }
+        },
         "node_modules/express/node_modules/debug": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
@@ -15799,6 +15814,7 @@
                 "axios": "^1.7.7",
                 "dotenv": "^16.4.5",
                 "express": "^5.0.0",
+                "express-rate-limit": "^7.4.1",
                 "fast-xml-parser": "^4.5.0",
                 "luxon": "^3.5.0"
             },

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
         "dotenv": "^16.4.5",
         "express": "^5.0.0",
         "fast-xml-parser": "^4.5.0",
-        "luxon": "^3.5.0"
+        "luxon": "^3.5.0",
+        "express-rate-limit": "^7.4.1"
     },
     "devDependencies": {
         "@types/express": "^5.0.0",


### PR DESCRIPTION
Fixes [https://github.com/kylejb/space-station-tracker/security/code-scanning/4](https://github.com/kylejb/space-station-tracker/security/code-scanning/4)

To fix the problem, we will introduce a rate-limiting middleware using the `express-rate-limit` package. This middleware will limit the number of requests that can be made to the server within a specified time window. We will apply this middleware to the entire application to ensure that all routes, including the one serving the file, are protected.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server.ts` file.
3. Set up the rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter middleware to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._