### PR TITLE
chore(github): set permissions in workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: CI before CD to Heroku
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kylejb/space-station-tracker/security/code-scanning/5](https://github.com/kylejb/space-station-tracker/security/code-scanning/5)

To fix the problem, you should explicitly add a `permissions` block to the workflow file. Since the job does not appear to push changes, manage issues, nor perform other actions requiring write access, it only requires read access to repository contents. Therefore, the best fix is to add `permissions: contents: read` to the top-level of the workflow YAML, right after the `name` or `on` block (before the `jobs` block). This ensures that all jobs in the workflow inherit a restricted set of permissions unless explicitly overridden. No new imports, methods, or definitions are needed beyond adding the correct YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
