### PR TITLE
fix(test): polyfill WebGPU constants to resolve three.js errors

### DIFF
--- a/web/__mocks__/react-globe.gl.js
+++ b/web/__mocks__/react-globe.gl.js
@@ -1,2 +1,0 @@
-const Globe = () => null;
-export default Globe;

--- a/web/__mocks__/three.js
+++ b/web/__mocks__/three.js
@@ -1,4 +1,0 @@
-export const Mesh = jest.fn();
-export const MeshLambertMaterial = jest.fn();
-export const SphereGeometry = jest.fn();
-export const MultiplyOperation = 0;

--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -1,1 +1,38 @@
 import '@testing-library/jest-dom';
+
+// Polyfill WebGPU constants that three.js requires
+globalThis.GPUShaderStage = {
+    VERTEX: 1,
+    FRAGMENT: 2,
+    COMPUTE: 4,
+};
+
+globalThis.GPUBufferUsage = {
+    MAP_READ: 1,
+    MAP_WRITE: 2,
+    COPY_SRC: 4,
+    COPY_DST: 8,
+    INDEX: 16,
+    VERTEX: 32,
+    UNIFORM: 64,
+    STORAGE: 128,
+    INDIRECT: 256,
+    QUERY_RESOLVE: 512,
+};
+
+globalThis.GPUTextureUsage = {
+    COPY_SRC: 1,
+    COPY_DST: 2,
+    TEXTURE_BINDING: 4,
+    STORAGE_BINDING: 8,
+    RENDER_ATTACHMENT: 16,
+    TRANSIENT_ATTACHMENT: 32,
+};
+
+globalThis.GPUColorWrite = {
+    RED: 1,
+    GREEN: 2,
+    BLUE: 4,
+    ALPHA: 8,
+    ALL: 15,
+};

--- a/web/package.json
+++ b/web/package.json
@@ -80,8 +80,6 @@
         ],
         "verbose": true,
         "moduleNameMapper": {
-            "^three$": "<rootDir>/__mocks__/three.js",
-            "^react-globe.gl$": "<rootDir>/__mocks__/react-globe.gl.js",
             "@common/(.*)": "<rootDir>/src/common/$1",
             "@components/(.*)": "<rootDir>/src/components/$1",
             "@containers/(.*)": "<rootDir>/src/containers/$1",


### PR DESCRIPTION
Replace mocks with WebGPU API polyfills (GPUShaderStage, GPUBufferUsage, etc.) in jest.setup.ts and update transformIgnorePatterns to include three package. Prevents "Cannot read properties of undefined (reading 'VERTEX')" error when three.webgpu.js loads in jsdom environment.